### PR TITLE
Re-apply BlockData when a block is replaced via ReplacementTask

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>dev.th3shadowbroker.spigot</groupId>
   <artifactId>OuroborosMines</artifactId>
-  <version>1.9.2-SNAPSHOT</version>
+  <version>1.9.3-SNAPSHOT</version>
 
   <properties>
     <plugin.name>${project.artifactId}</plugin.name>

--- a/src/main/java/dev/th3shadowbroker/ouroboros/mines/util/ReplacementTask.java
+++ b/src/main/java/dev/th3shadowbroker/ouroboros/mines/util/ReplacementTask.java
@@ -23,6 +23,7 @@ import dev.th3shadowbroker.ouroboros.mines.OuroborosMines;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
+import org.bukkit.block.data.BlockData;
 import org.bukkit.scheduler.BukkitTask;
 
 public class ReplacementTask implements Runnable {
@@ -33,19 +34,23 @@ public class ReplacementTask implements Runnable {
 
     private final Location location;
 
+    private final BlockData blockData;
+
     private final OuroborosMines plugin = OuroborosMines.INSTANCE;
 
     public ReplacementTask(Location blockLocation, Material material, long cooldownSeconds) {
-        location = blockLocation;
-        minedMaterial = material;
-        task = plugin.getServer().getScheduler().runTaskLater(plugin, this, cooldownSeconds);
-        plugin.getTaskManager().register(this);
+        this.location = blockLocation;
+        this.minedMaterial = material;
+        this.task = plugin.getServer().getScheduler().runTaskLater(plugin, this, cooldownSeconds);
+        this.plugin.getTaskManager().register(this);
+        this.blockData = blockLocation.getBlock().getBlockData();
         //plugin.getLogger().info(String.format("Scheduled restoration of %s %s %s in %s as %s", location.getX(), location.getY(), location.getZ(), cooldownSeconds, minedMaterial.name()));
     }
 
     @Override
     public void run() {
         location.getBlock().setType(minedMaterial);
+        location.getBlock().setBlockData(blockData);
         if (!getTask().isCancelled()) plugin.getTaskManager().unregister(this);
     }
 


### PR DESCRIPTION
- Re-apply BlockData when a block is replaced to keep block rotation and other data-based properties (fixes #48)